### PR TITLE
Wait for Async Info before rendering PDP

### DIFF
--- a/src/@vtex/gatsby-theme-vtex/components/ProductPage/AboveTheFold.tsx
+++ b/src/@vtex/gatsby-theme-vtex/components/ProductPage/AboveTheFold.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import Container from '@vtex/gatsby-theme-vtex/src/components/Container'
-import SuspenseSSR from '@vtex/gatsby-theme-vtex/src/components/Suspense/SSR'
 import ProductImageGallery from '@vtex/gatsby-theme-vtex/src/components/ProductImageGallery'
 import { useDetailsImage } from '@vtex/gatsby-theme-vtex/src/sdk/product/useDetailsImage'
 import { useGalleryItems } from '@vtex/gatsby-theme-vtex/src/sdk/product/useGalleryItems'
@@ -12,12 +11,12 @@ import {
   Breadcrumb,
   ProductDetailsTitle,
 } from '@vtex/store-ui'
-import React, { FC, lazy } from 'react'
+import React, { FC, Suspense } from 'react'
+import { isServer } from '@vtex/gatsby-theme-vtex/src/utils/env'
 
 import AsyncInfoContainer from './Above/Async/Container'
 import AsyncInfoPreview from './Above/Async/Preview'
-
-const AsyncInfo = lazy(() => import('./Above/Async/index'))
+import AsyncInfo from './Above/Async'
 
 const variant = 'default'
 
@@ -50,9 +49,11 @@ const AboveTheFold: FC<ProductPageProps> = ({
             </ProductDetailsTitle>
 
             <AsyncInfoContainer>
-              <SuspenseSSR fallback={<AsyncInfoPreview />}>
-                <AsyncInfo slug={slug!} />
-              </SuspenseSSR>
+              {isServer ? null : (
+                <Suspense fallback={<AsyncInfoPreview />}>
+                  <AsyncInfo slug={slug!} />
+                </Suspense>
+              )}
             </AsyncInfoContainer>
           </Card>
         </Grid>


### PR DESCRIPTION
## What's the purpose of this pull request?
Removes the multiple loading steps from the PDP, thus waiting for Async product info for rendering the page

## How it works? 
<em>Tell us the role of the new feature, or component, in its context.</em>

## How to test it?
<em>Describe the steps with bullet points. Is there any external reference, link, or example?</em> 

## References
<em>Spread the knowledge: is this any content you used to create this PR that is worth sharing?</em>  

<em>Extra tip: add references to related issues or mention people important to this PR may be good for the documentation and reviewing process</em> 
