### PR TITLE
SEO | Add noindex to non-static search pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@vtex/gatsby-plugin-graphql": "^0.230.0",
     "@vtex/gatsby-plugin-nginx": "^0.230.0",
     "@vtex/gatsby-source-vtex": "^0.233.0",
-    "@vtex/gatsby-theme-store": "^0.232.0",
+    "@vtex/gatsby-theme-store": "^0.234.0-alpha.0",
     "@vtex/store-ui": "^0.230.0",
     "babel-preset-gatsby": "^0.5.5",
     "dotenv": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@vtex/gatsby-plugin-graphql": "^0.230.0",
     "@vtex/gatsby-plugin-nginx": "^0.230.0",
     "@vtex/gatsby-source-vtex": "^0.233.0",
-    "@vtex/gatsby-theme-store": "^0.234.0-alpha.0",
+    "@vtex/gatsby-theme-store": "^0.234.0-alpha.1",
     "@vtex/store-ui": "^0.230.0",
     "babel-preset-gatsby": "^0.5.5",
     "dotenv": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@vtex/gatsby-plugin-graphql": "^0.230.0",
     "@vtex/gatsby-plugin-nginx": "^0.230.0",
     "@vtex/gatsby-source-vtex": "^0.233.0",
-    "@vtex/gatsby-theme-store": "^0.234.0-alpha.2",
+    "@vtex/gatsby-theme-store": "^0.234.0",
     "@vtex/store-ui": "^0.230.0",
     "babel-preset-gatsby": "^0.5.5",
     "dotenv": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@vtex/gatsby-plugin-graphql": "^0.230.0",
     "@vtex/gatsby-plugin-nginx": "^0.230.0",
     "@vtex/gatsby-source-vtex": "^0.233.0",
-    "@vtex/gatsby-theme-store": "^0.234.0-alpha.1",
+    "@vtex/gatsby-theme-store": "^0.234.0-alpha.2",
     "@vtex/store-ui": "^0.230.0",
     "babel-preset-gatsby": "^0.5.5",
     "dotenv": "^8.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3126,10 +3126,10 @@
     p-map "^4.0.0"
     uuid "^8.3.0"
 
-"@vtex/gatsby-theme-store@^0.234.0-alpha.1":
-  version "0.234.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@vtex/gatsby-theme-store/-/gatsby-theme-store-0.234.0-alpha.1.tgz#9886cee22b323f5dc3f07e048817d8d026755340"
-  integrity sha512-Aaa8i5/xzpwVM5YnoSZ8LkKkw8JaJBCZAsX1+sgmjLnkdakmL+k+w0y5VAR3yJEEKDiuASdu69QlR4PVEDftfQ==
+"@vtex/gatsby-theme-store@^0.234.0-alpha.2":
+  version "0.234.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@vtex/gatsby-theme-store/-/gatsby-theme-store-0.234.0-alpha.2.tgz#428f847fbd22b952f18ae76a4765f9b41be864a2"
+  integrity sha512-TGflyCHln/MriZ+XpwXA8v8LkbeUmMFZe7L4IxOQCB6zt4ObuPApkQibwW8ozvzPYaMW6bInvtTWQR+14pvwpw==
   dependencies:
     "@theme-ui/match-media" "^0.3.1"
     "@vtex/gatsby-plugin-graphql" "^0.214.0-alpha.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3126,10 +3126,10 @@
     p-map "^4.0.0"
     uuid "^8.3.0"
 
-"@vtex/gatsby-theme-store@^0.234.0-alpha.0":
-  version "0.234.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@vtex/gatsby-theme-store/-/gatsby-theme-store-0.234.0-alpha.0.tgz#8d52d9be8c4e0d64b36c3d7781a2a8f42f1ecf09"
-  integrity sha512-91NZ5O5LS0qARL2Fzis74KITk3NxIVgcGF4T8KOfhulucwiDmMYLhvWBYeh6A6n6N+qTgYUT2OksMxpRC9YW+Q==
+"@vtex/gatsby-theme-store@^0.234.0-alpha.1":
+  version "0.234.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@vtex/gatsby-theme-store/-/gatsby-theme-store-0.234.0-alpha.1.tgz#9886cee22b323f5dc3f07e048817d8d026755340"
+  integrity sha512-Aaa8i5/xzpwVM5YnoSZ8LkKkw8JaJBCZAsX1+sgmjLnkdakmL+k+w0y5VAR3yJEEKDiuASdu69QlR4PVEDftfQ==
   dependencies:
     "@theme-ui/match-media" "^0.3.1"
     "@vtex/gatsby-plugin-graphql" "^0.214.0-alpha.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3126,10 +3126,10 @@
     p-map "^4.0.0"
     uuid "^8.3.0"
 
-"@vtex/gatsby-theme-store@^0.232.0":
-  version "0.232.0"
-  resolved "https://registry.yarnpkg.com/@vtex/gatsby-theme-store/-/gatsby-theme-store-0.232.0.tgz#bfda78019023713d4b2cc04cab225e81482501a1"
-  integrity sha512-DSk5+bkVZFuCTHFH89T//lqFPDvQn8m33s9PM5OO/f30Dne/vR3HNou66CguU7isSJ42t5JePcNy73chWKp71w==
+"@vtex/gatsby-theme-store@^0.234.0-alpha.0":
+  version "0.234.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@vtex/gatsby-theme-store/-/gatsby-theme-store-0.234.0-alpha.0.tgz#8d52d9be8c4e0d64b36c3d7781a2a8f42f1ecf09"
+  integrity sha512-91NZ5O5LS0qARL2Fzis74KITk3NxIVgcGF4T8KOfhulucwiDmMYLhvWBYeh6A6n6N+qTgYUT2OksMxpRC9YW+Q==
   dependencies:
     "@theme-ui/match-media" "^0.3.1"
     "@vtex/gatsby-plugin-graphql" "^0.214.0-alpha.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3126,10 +3126,10 @@
     p-map "^4.0.0"
     uuid "^8.3.0"
 
-"@vtex/gatsby-theme-store@^0.234.0-alpha.2":
-  version "0.234.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@vtex/gatsby-theme-store/-/gatsby-theme-store-0.234.0-alpha.2.tgz#428f847fbd22b952f18ae76a4765f9b41be864a2"
-  integrity sha512-TGflyCHln/MriZ+XpwXA8v8LkbeUmMFZe7L4IxOQCB6zt4ObuPApkQibwW8ozvzPYaMW6bInvtTWQR+14pvwpw==
+"@vtex/gatsby-theme-store@^0.234.0":
+  version "0.234.0"
+  resolved "https://registry.yarnpkg.com/@vtex/gatsby-theme-store/-/gatsby-theme-store-0.234.0.tgz#b719b6ab3c96df15717d5c0ee4984609fc2947fd"
+  integrity sha512-lciL01/PaVE8QTAurD6Yzx/tfhaOs48C04Ne/Y+Psznt0Qhe7n87Pj4poEQhtiaaarrQvzDC9Z3M0lNby24H3g==
   dependencies:
     "@theme-ui/match-media" "^0.3.1"
     "@vtex/gatsby-plugin-graphql" "^0.214.0-alpha.6"


### PR DESCRIPTION
## What's the purpose of this pull request?
Improve SEO by reducing the number of search pages indexed by google, thus not breaking GoogleBot Budget

## How it works? 
Add `<meta name="robots" content="noindex" />` to non pre-rendered search pages. Pre rendered search pages are still indexed. 

Pages that are still indexed are:
1. All category tree since we are now pre-rendering all of them
2. Any landing page containing a search

Pages that are blocked from indexing:
1. category pages with filters
2. All full text search

## How to test it?
Explore the category tree. Any page in the category tree should be indexable. Adding any filter to the category should add the 
`<meta name="robots" content="noindex" />` to the html's head

## References
<em>Spread the knowledge: is there any content you used to create this PR that is worth sharing?</em>  

<em>Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process</em> 
