### PR TITLE
SEO | Respond with 404 when entering a non existing category

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@vtex/gatsby-plugin-graphql": "^0.230.0",
     "@vtex/gatsby-plugin-nginx": "^0.230.0",
     "@vtex/gatsby-source-vtex": "^0.233.0",
-    "@vtex/gatsby-theme-store": "^0.234.0",
+    "@vtex/gatsby-theme-store": "^0.235.0-alpha.0",
     "@vtex/store-ui": "^0.230.0",
     "babel-preset-gatsby": "^0.5.5",
     "dotenv": "^8.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3126,10 +3126,10 @@
     p-map "^4.0.0"
     uuid "^8.3.0"
 
-"@vtex/gatsby-theme-store@^0.234.0":
-  version "0.234.0"
-  resolved "https://registry.yarnpkg.com/@vtex/gatsby-theme-store/-/gatsby-theme-store-0.234.0.tgz#b719b6ab3c96df15717d5c0ee4984609fc2947fd"
-  integrity sha512-lciL01/PaVE8QTAurD6Yzx/tfhaOs48C04Ne/Y+Psznt0Qhe7n87Pj4poEQhtiaaarrQvzDC9Z3M0lNby24H3g==
+"@vtex/gatsby-theme-store@^0.235.0-alpha.0":
+  version "0.235.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@vtex/gatsby-theme-store/-/gatsby-theme-store-0.235.0-alpha.0.tgz#a7e92f9f89aa38cb0d91ff89969ed16f691ad33c"
+  integrity sha512-HsFSssiLGgx1vnauy9eCW5iMSRsacG8zXslM0mZV1B579VjOFjUBOf+JJjXJle/EDI83T9KYDUbjL5A/OezV/Q==
   dependencies:
     "@theme-ui/match-media" "^0.3.1"
     "@vtex/gatsby-plugin-graphql" "^0.214.0-alpha.6"


### PR DESCRIPTION
## What's the purpose of this pull request?
Correctly redirect the user when it enters a non existing category

## How it works? 
Since we have generated all the category tree on the server, if the user enters in `/foo/bar` and receives the client-side search html, this means the user entered in a non existing category and thus should be redirected to a `/404` page. 

The only corner case we have right now is for full text searches. This should be addressed once we move all full text searches to `/s/:term` 

## How to test it?
Enter in a non existing category, for instance `/foo/bar` and you should be redirected correctly to `/404` page. 
Entering a valid search page with filters applied should not redirect you to a `/404` page


## References
<em>Spread the knowledge: is there any content you used to create this PR that is worth sharing?</em>  

<em>Extra tip: adding references to related issues or mentioning people important to this PR may be good for the documentation and reviewing process</em> 
