### PR TITLE
fix: passes the workspace to the cms plugin

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -101,6 +101,7 @@ module.exports = {
       resolve: '@vtex/gatsby-plugin-cms',
       options: {
         tenant: STORE_ID,
+        workspace,
       },
     },
     {


### PR DESCRIPTION
## What's the purpose of this pull request?
Codeby decided that it would use SFJ in a workspace other than `master` so it was causing an error because the cms n received the specific workspace.

## How it works? 
We pass the workspace as a plugin parameter

## How to test it?
<em>Describe the steps with bullet points. Is there any external reference, link, or example?</em> 

## References
<em>Spread the knowledge: is this any content you used to create this PR that is worth sharing?</em>  

<em>Extra tip: add references to related issues or mention people important to this PR may be good for the documentation and reviewing process</em> 
