### PR TITLE
Dependabot configuration to automatically update VTEX packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+      time: '08:30'
+      timezone: 'America/Sao_Paulo'
+    allow:
+      - dependency-name: '@vtex/*'
+    open-pull-requests-limit: 5
+    reviewers:
+      - 'vtex/faststore'
+      - 'vtex/store-framework'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,9 @@ updates:
     ignored_updates:
       - match:
           update_type: 'semver:major'
-    automerged_updates:
-      - match:
-          update_type: 'semver:patch'
+    # automerged_updates:
+    #   - match:
+    #       update_type: 'semver:patch'
     open-pull-requests-limit: 5
     reviewers:
       - 'vtex/faststore'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,5 @@
 version: 2
 updates:
-  ignored_updates:
-      - match:
-          update_type: 'semver:major'
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,12 @@ updates:
       timezone: 'America/Sao_Paulo'
     allow:
       - dependency-name: '@vtex/*'
+    ignored_updates:
+      - match:
+          update_type: 'semver:major'
+    automerged_updates:
+      - match:
+          update_type: 'semver:patch'
     open-pull-requests-limit: 5
     reviewers:
       - 'vtex/faststore'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,8 @@
 version: 2
 updates:
+  ignored_updates:
+      - match:
+          update_type: 'semver:major'
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
@@ -8,12 +11,6 @@ updates:
       timezone: 'America/Sao_Paulo'
     allow:
       - dependency-name: '@vtex/*'
-    ignored_updates:
-      - match:
-          update_type: 'semver:major'
-    # automerged_updates:
-    #   - match:
-    #       update_type: 'semver:patch'
     open-pull-requests-limit: 5
     reviewers:
       - 'vtex/faststore'


### PR DESCRIPTION
- I did this config only for `storecomponents` for tests purposes.

This [FastStore PR](https://github.com/vtex/faststore/pull/539) creates the Lerna auto-publish pipeline.

[Dependabot Docs](https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates)
