### PR TITLE
Add @vtex-sites/cms-schema as default code reviewr for schema changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Make @vtex-sites/cms-schema default reviewer for all schema changes for CMS
+src/@vtex/gatsby-plugin-cms/ @vtex-sites/cms-schema


### PR DESCRIPTION
## What's the purpose of this pull request?
<em>Add @vtex-sites/cms-schema code owner of all schema changes made in vtex-sites.</em>

[JIRA CMS-386](https://vtex-dev.atlassian.net/jira/software/projects/CMS/boards/104?selectedIssue=CMS-386)

## How to test it?
<em>Change CMS schema, open a PR, watch for @vtex-sites/cms-schema as a reviewer.</em> 

