### PR TITLE
Add minicart warning when orderForm has error

### DIFF
--- a/src/@vtex/gatsby-plugin-theme-ui/minicart.ts
+++ b/src/@vtex/gatsby-plugin-theme-ui/minicart.ts
@@ -48,6 +48,10 @@ const custom: SxStyleProp = {
           ...btn,
         },
       },
+      warning: {
+        px: ['6px', '16px'],
+        py: ['10px', '16px'],
+      },
     },
   },
 }

--- a/src/@vtex/gatsby-theme-store/components/Layout.tsx
+++ b/src/@vtex/gatsby-theme-store/components/Layout.tsx
@@ -2,7 +2,6 @@ import React, { Fragment, lazy } from 'react'
 import type { FC } from 'react'
 import { SuspenseViewport } from '@vtex/store-ui'
 
-import Toast from '../../../components/Toast'
 import Header from './Header'
 
 const loader = () => import('./Footer')
@@ -12,7 +11,6 @@ const Footer = lazy(loader)
 const Layout: FC = ({ children }) => (
   <Fragment>
     <Header />
-    <Toast />
     {children}
     <SuspenseViewport fallback={null} preloader={loader}>
       <Footer />

--- a/src/@vtex/gatsby-theme-store/components/Minicart/Drawer/Warning.tsx
+++ b/src/@vtex/gatsby-theme-store/components/Minicart/Drawer/Warning.tsx
@@ -5,7 +5,7 @@ import { useToast } from '@vtex/gatsby-theme-store'
 export const MinicartWarning = () => {
   return (
     <Box variant="minicart.drawer.warning">
-      <Toast {...useToast()} disablePortal type="error" />
+      <Toast {...useToast()} type="error" />
     </Box>
   )
 }

--- a/src/@vtex/gatsby-theme-store/components/Minicart/Drawer/Warning.tsx
+++ b/src/@vtex/gatsby-theme-store/components/Minicart/Drawer/Warning.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import { Toast, Box } from '@vtex/store-ui'
+import { useToast } from '@vtex/gatsby-theme-store'
+
+export const MinicartWarning = () => {
+  return (
+    <Box variant="minicart.drawer.warning">
+      <Toast {...useToast()} disablePortal type="error" />
+    </Box>
+  )
+}


### PR DESCRIPTION
## What's the purpose of this pull request?
As the title says

## How it works? 
Show a toast inside the minicart when orderform has error

## How to test it?
Add jobs notebook more than 50 and you will see a warning inside the minicart

## References
<em>Spread the knowledge: is this any content you used to create this PR that is worth sharing?</em>  

<em>Extra tip: add references to related issues or mention people important to this PR may be good for the documentation and reviewing process</em> 
